### PR TITLE
Add links page with centralized navigation hub

### DIFF
--- a/app/components/navigation/navigation.tsx
+++ b/app/components/navigation/navigation.tsx
@@ -20,6 +20,12 @@ const navigation: NavigationItem[] = [
     {
         name: 'Apps', href: '#', children: [
             {
+                name: "Atlasz",
+                href: "https://www.atlasz.eu",
+                description: 'AI-powered Transport Management System',
+                target: "_blank"
+            },
+            {
                 name: "STRV.AI",
                 href: "https://strv.ai",
                 description: 'AI Powered Health & Fitness platform for athletes and coaches.',

--- a/app/components/navigation/navigation.tsx
+++ b/app/components/navigation/navigation.tsx
@@ -22,7 +22,7 @@ const navigation: NavigationItem[] = [
             {
                 name: "Atlasz",
                 href: "https://www.atlasz.eu",
-                description: 'AI-powered Transport Management System',
+                description: 'AI-powered Transport Management System that brings your fleet, routes, and freight into one intelligent workspace.',
                 target: "_blank"
             },
             {

--- a/app/links/components/MiniChat.tsx
+++ b/app/links/components/MiniChat.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import classNames from "classnames";
+import FPIcon from "@/icons/FPIcon";
+
+interface Message {
+    role: "bot" | "user";
+    text: string;
+}
+
+const script: Message[] = [
+    { role: "bot", text: "Hi! 👋 Welcome to Follow The Pattern." },
+    { role: "user", text: "Can you build an AI-powered app for us?" },
+    { role: "bot", text: "Absolutely — from prototype to production. 🚀" },
+    { role: "user", text: "Love it. How do we get started?" },
+    { role: "bot", text: 'Just tap "Email Us" below and say hi!' },
+];
+
+const TYPING_MS = 1100;
+const READ_MS = 850;
+const RESTART_MS = 3000;
+
+function TypingDots() {
+    return (
+        <div className="flex items-center space-x-1">
+            {[0, 1, 2].map((i) => (
+                <motion.span
+                    key={i}
+                    className="h-2 w-2 rounded-full bg-gray-400"
+                    animate={{ opacity: [0.3, 1, 0.3], y: [0, -2, 0] }}
+                    transition={{ duration: 0.9, repeat: Infinity, delay: i * 0.15 }}
+                />
+            ))}
+        </div>
+    );
+}
+
+function Bubble({ message }: { message: Message }) {
+    const isBot = message.role === "bot";
+    return (
+        <motion.div
+            layout
+            initial={{ opacity: 0, y: 8, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ type: "spring", stiffness: 500, damping: 30 }}
+            className={classNames("flex w-full", isBot ? "justify-start" : "justify-end")}
+        >
+            <span
+                className={classNames(
+                    "max-w-[80%] rounded-2xl px-4 py-2 text-sm shadow-sm",
+                    isBot
+                        ? "rounded-bl-sm bg-gray-100 text-gray-900"
+                        : "rounded-br-sm bg-blue-600 text-white"
+                )}
+            >
+                {message.text}
+            </span>
+        </motion.div>
+    );
+}
+
+export default function MiniChat({ className }: { className?: string }) {
+    const [count, setCount] = useState(0);
+    const [typing, setTyping] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        const timers: ReturnType<typeof setTimeout>[] = [];
+        const at = (delay: number, fn: () => void) =>
+            timers.push(setTimeout(() => !cancelled && fn(), delay));
+
+        const run = () => {
+            setCount(0);
+            setTyping(false);
+            let t = 600;
+            script.forEach((msg, i) => {
+                if (msg.role === "bot") {
+                    at(t, () => setTyping(true));
+                    t += TYPING_MS;
+                    at(t, () => {
+                        setTyping(false);
+                        setCount(i + 1);
+                    });
+                    t += READ_MS;
+                } else {
+                    at(t, () => setCount(i + 1));
+                    t += READ_MS;
+                }
+            });
+            at(t + RESTART_MS, run);
+        };
+
+        run();
+        return () => {
+            cancelled = true;
+            timers.forEach(clearTimeout);
+        };
+    }, []);
+
+    return (
+        <div
+            className={classNames(
+                className,
+                "w-full overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-md"
+            )}
+        >
+            <div className="flex items-center space-x-3 border-b border-gray-100 px-4 py-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-50">
+                    <FPIcon className="h-5 w-5 text-blue-500" />
+                </div>
+                <div className="flex flex-col">
+                    <span className="text-sm font-semibold text-gray-900">Follow The Pattern</span>
+                    <span className="flex items-center text-xs font-light text-gray-500">
+                        <span className="mr-1.5 h-2 w-2 rounded-full bg-green-500" />
+                        Online
+                    </span>
+                </div>
+            </div>
+            <div className="flex h-64 flex-col justify-end space-y-3 p-4">
+                <AnimatePresence initial={false}>
+                    {script.slice(0, count).map((message, i) => (
+                        <Bubble key={i} message={message} />
+                    ))}
+                    {typing && (
+                        <motion.div
+                            key="typing"
+                            layout
+                            initial={{ opacity: 0, y: 8 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0 }}
+                            className="flex justify-start"
+                        >
+                            <span className="rounded-2xl rounded-bl-sm bg-gray-100 px-4 py-3">
+                                <TypingDots />
+                            </span>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+            </div>
+        </div>
+    );
+}

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -30,6 +30,7 @@ const links: LinkItem[] = [
         label: "Apps",
         description: "Products we build and ship",
         children: [
+            { label: "Atlasz", description: "AI-powered Transport Management System", href: "https://www.atlasz.eu", target: "_blank" },
             { label: "STRV.AI", description: "AI-powered nutrition & training coach", href: "https://strv.ai", target: "_blank" },
         ],
     },

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -6,6 +6,7 @@ import Credits from "../(public)/components/credits";
 import FPIcon from "@/icons/FPIcon";
 import RightArrowIcon from "@/icons/RightArrowIcon";
 import ChevronDownIcon from "@/icons/ChevronDownIcon";
+import MiniChat from "./components/MiniChat";
 
 export const metadata: Metadata = {
     title: "Follow The Pattern — Links",
@@ -112,7 +113,8 @@ export default function LinksPage() {
                         Building applications that enable companies to do more
                     </p>
                 </header>
-                <div className="mt-12 flex w-full max-w-md flex-col space-y-4">
+                <MiniChat className="mt-10 max-w-md" />
+                <div className="mt-6 flex w-full max-w-md flex-col space-y-4">
                     {links.map((item) =>
                         item.children ? (
                             <DropdownItem key={item.label} item={item} />

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -5,51 +5,70 @@ import PatternBackground from "../components/patternBackground";
 import Credits from "../(public)/components/credits";
 import FPIcon from "@/icons/FPIcon";
 import RightArrowIcon from "@/icons/RightArrowIcon";
+import ChevronDownIcon from "@/icons/ChevronDownIcon";
 
 export const metadata: Metadata = {
     title: "Follow The Pattern — Links",
-    description: "All of Follow The Pattern in one place — services, blog, podcast, courses and how to get in touch.",
+    description: "All of Follow The Pattern in one place — apps, podcast, courses and how to get in touch.",
 };
 
-interface LinkItem {
+interface LinkLeaf {
     label: string;
     description?: string;
     href: string;
+    target?: string;
+}
+
+interface LinkItem extends Partial<LinkLeaf> {
+    label: string;
+    children?: LinkLeaf[];
 }
 
 const links: LinkItem[] = [
-    { label: "Services", description: "Build AI-powered apps with us", href: "/services" },
-    { label: "Blog", description: "Lessons from building AI-powered apps", href: "/blog" },
+    {
+        label: "Apps",
+        description: "Products we build and ship",
+        children: [
+            { label: "STRV.AI", description: "AI-powered nutrition & training coach", href: "https://strv.ai", target: "_blank" },
+        ],
+    },
     { label: "Podcast", description: "Conversations on modern software", href: "/podcast" },
-    { label: "Go Basic Course", description: "Start writing Go from the ground up", href: "/learn/en/gobasic" },
-    { label: "Go Advanced Course", description: "Level up your Go skills", href: "/learn/en/goadvanced" },
-    { label: "Book a Call", description: "Schedule a meeting with us", href: "/book" },
-    { label: "Contact", description: "Send us a message", href: "/contact" },
+    {
+        label: "Courses",
+        description: "Learn to build with us",
+        children: [
+            { label: "Go Basic", description: "Start writing Go from the ground up", href: "/learn/en/gobasic" },
+            { label: "Go Advanced", description: "Level up your Go skills", href: "/learn/en/goadvanced" },
+        ],
+    },
     { label: "Email Us", description: "csaba@followthepattern.net", href: "mailto:csaba@followthepattern.net" },
 ];
 
-interface LinkButtonProperties {
-    item: LinkItem;
+const itemClassName =
+    "group flex items-center justify-between w-full rounded-lg border border-gray-200 bg-white px-5 py-4 shadow-md transition ease-in-out duration-150 hover:bg-gray-50 hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700";
+
+function ItemLabel({ label, description }: { label: string; description?: string }) {
+    return (
+        <span className="flex flex-col text-left">
+            <span className="text-lg font-medium text-gray-900">{label}</span>
+            {description && <span className="text-sm font-light text-gray-500">{description}</span>}
+        </span>
+    );
 }
 
-function LinkButton({ item }: LinkButtonProperties) {
-    const className = "group flex items-center justify-between w-full rounded-lg border border-gray-200 bg-white px-5 py-4 shadow-md transition ease-in-out duration-150 hover:bg-gray-50 hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700";
-
+function LeafLink({ item, nested }: { item: LinkLeaf; nested?: boolean }) {
     const content = (
         <>
-            <span className="flex flex-col text-left">
-                <span className="text-lg font-medium text-gray-900">{item.label}</span>
-                {item.description && (
-                    <span className="text-sm font-light text-gray-500">{item.description}</span>
-                )}
-            </span>
+            <ItemLabel label={item.label} description={item.description} />
             <RightArrowIcon className="ml-4 h-5 w-5 flex-none text-gray-400 transition-transform ease-in-out duration-150 group-hover:translate-x-1 group-hover:text-blue-600" />
         </>
     );
 
-    if (item.href.startsWith("mailto:")) {
+    const className = classNames(itemClassName, nested && "bg-gray-50/80");
+
+    if (item.href.startsWith("mailto:") || item.target) {
         return (
-            <a href={item.href} className={className}>
+            <a href={item.href} target={item.target} rel={item.target === "_blank" ? "noreferrer" : undefined} className={className}>
                 {content}
             </a>
         );
@@ -59,6 +78,22 @@ function LinkButton({ item }: LinkButtonProperties) {
         <Link href={item.href} className={className}>
             {content}
         </Link>
+    );
+}
+
+function DropdownItem({ item }: { item: LinkItem }) {
+    return (
+        <details className="group w-full">
+            <summary className={classNames(itemClassName, "cursor-pointer list-none [&::-webkit-details-marker]:hidden")}>
+                <ItemLabel label={item.label} description={item.description} />
+                <ChevronDownIcon className="ml-4 h-5 w-5 flex-none text-gray-400 transition-transform ease-in-out duration-150 group-open:rotate-180 group-hover:text-blue-600" />
+            </summary>
+            <div className="mt-3 flex flex-col space-y-3 pl-4">
+                {item.children!.map((child) => (
+                    <LeafLink key={child.href} item={child} nested />
+                ))}
+            </div>
+        </details>
     );
 }
 
@@ -78,9 +113,13 @@ export default function LinksPage() {
                     </p>
                 </header>
                 <div className="mt-12 flex w-full max-w-md flex-col space-y-4">
-                    {links.map((item) => (
-                        <LinkButton key={item.href} item={item} />
-                    ))}
+                    {links.map((item) =>
+                        item.children ? (
+                            <DropdownItem key={item.label} item={item} />
+                        ) : (
+                            <LeafLink key={item.href} item={item as LinkLeaf} />
+                        )
+                    )}
                 </div>
                 <div className="w-full max-w-md">
                     <Credits />

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -30,7 +30,7 @@ const links: LinkItem[] = [
         label: "Apps",
         description: "Products we build and ship",
         children: [
-            { label: "Atlasz", description: "AI-powered Transport Management System", href: "https://www.atlasz.eu", target: "_blank" },
+            { label: "Atlasz", description: "AI-powered Transport Management System that brings your fleet, routes, and freight into one intelligent workspace.", href: "https://www.atlasz.eu", target: "_blank" },
             { label: "STRV.AI", description: "AI-powered nutrition & training coach", href: "https://strv.ai", target: "_blank" },
         ],
     },
@@ -104,9 +104,13 @@ export default function LinksPage() {
         <main className="min-h-screen">
             <PatternBackground className="flex min-h-screen flex-col items-center px-6 py-16 sm:py-24">
                 <header className="flex flex-col items-center text-center">
-                    <div className="flex h-24 w-24 items-center justify-center rounded-3xl bg-white shadow-md">
+                    <Link
+                        href="/"
+                        aria-label="Go to Follow The Pattern home"
+                        className="flex h-24 w-24 items-center justify-center rounded-3xl bg-white shadow-md transition ease-in-out duration-150 hover:scale-105 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700"
+                    >
                         <FPIcon className="h-12 w-12 text-blue-500" />
-                    </div>
+                    </Link>
                     <h1 className="mt-6 text-3xl font-bold text-gray-900 sm:text-4xl">
                         Follow The Pattern
                     </h1>

--- a/app/links/page.tsx
+++ b/app/links/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import classNames from "classnames";
+import PatternBackground from "../components/patternBackground";
+import Credits from "../(public)/components/credits";
+import FPIcon from "@/icons/FPIcon";
+import RightArrowIcon from "@/icons/RightArrowIcon";
+
+export const metadata: Metadata = {
+    title: "Follow The Pattern — Links",
+    description: "All of Follow The Pattern in one place — services, blog, podcast, courses and how to get in touch.",
+};
+
+interface LinkItem {
+    label: string;
+    description?: string;
+    href: string;
+}
+
+const links: LinkItem[] = [
+    { label: "Services", description: "Build AI-powered apps with us", href: "/services" },
+    { label: "Blog", description: "Lessons from building AI-powered apps", href: "/blog" },
+    { label: "Podcast", description: "Conversations on modern software", href: "/podcast" },
+    { label: "Go Basic Course", description: "Start writing Go from the ground up", href: "/learn/en/gobasic" },
+    { label: "Go Advanced Course", description: "Level up your Go skills", href: "/learn/en/goadvanced" },
+    { label: "Book a Call", description: "Schedule a meeting with us", href: "/book" },
+    { label: "Contact", description: "Send us a message", href: "/contact" },
+    { label: "Email Us", description: "csaba@followthepattern.net", href: "mailto:csaba@followthepattern.net" },
+];
+
+interface LinkButtonProperties {
+    item: LinkItem;
+}
+
+function LinkButton({ item }: LinkButtonProperties) {
+    const className = "group flex items-center justify-between w-full rounded-lg border border-gray-200 bg-white px-5 py-4 shadow-md transition ease-in-out duration-150 hover:bg-gray-50 hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700";
+
+    const content = (
+        <>
+            <span className="flex flex-col text-left">
+                <span className="text-lg font-medium text-gray-900">{item.label}</span>
+                {item.description && (
+                    <span className="text-sm font-light text-gray-500">{item.description}</span>
+                )}
+            </span>
+            <RightArrowIcon className="ml-4 h-5 w-5 flex-none text-gray-400 transition-transform ease-in-out duration-150 group-hover:translate-x-1 group-hover:text-blue-600" />
+        </>
+    );
+
+    if (item.href.startsWith("mailto:")) {
+        return (
+            <a href={item.href} className={className}>
+                {content}
+            </a>
+        );
+    }
+
+    return (
+        <Link href={item.href} className={className}>
+            {content}
+        </Link>
+    );
+}
+
+export default function LinksPage() {
+    return (
+        <main className="min-h-screen">
+            <PatternBackground className="flex min-h-screen flex-col items-center px-6 py-16 sm:py-24">
+                <header className="flex flex-col items-center text-center">
+                    <div className="flex h-24 w-24 items-center justify-center rounded-3xl bg-white shadow-md">
+                        <FPIcon className="h-12 w-12 text-blue-500" />
+                    </div>
+                    <h1 className="mt-6 text-3xl font-bold text-gray-900 sm:text-4xl">
+                        Follow The Pattern
+                    </h1>
+                    <p className="mt-3 max-w-md text-lg font-light text-gray-600">
+                        Building applications that enable companies to do more
+                    </p>
+                </header>
+                <div className="mt-12 flex w-full max-w-md flex-col space-y-4">
+                    {links.map((item) => (
+                        <LinkButton key={item.href} item={item} />
+                    ))}
+                </div>
+                <div className="w-full max-w-md">
+                    <Credits />
+                </div>
+            </PatternBackground>
+        </main>
+    );
+}


### PR DESCRIPTION
## Summary
This PR adds a new links page (`/links`) that serves as a centralized hub for all Follow The Pattern resources and contact methods in one place.

## Key Changes
- Created new `app/links/page.tsx` with a dedicated links landing page
- Implemented `LinkButton` component that renders navigation items with descriptions and hover animations
- Added 8 curated links including services, blog, podcast, courses, booking, and contact options
- Configured page metadata with appropriate title and description for SEO
- Styled with a pattern background, centered layout, and interactive button states with smooth transitions
- Supports both internal Next.js links and external mailto links with appropriate handling

## Implementation Details
- The page uses a responsive grid layout with a maximum width constraint for optimal readability
- Each link item includes a label, optional description, and href
- The `LinkButton` component conditionally renders either a Next.js `Link` or an anchor tag based on whether the href is a mailto link
- Visual feedback includes hover scale effect, background color change, and animated arrow icon translation
- Integrated with existing `PatternBackground` and `Credits` components for consistent branding
- Fully accessible with focus-visible outline styling for keyboard navigation

https://claude.ai/code/session_01LzBPYb3xFNEkVr12b3dTki